### PR TITLE
Exploring better error handling

### DIFF
--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -122,9 +122,7 @@ def get_items(modules_df, cname):
         )
     except KeyError:
         raise KeyError(
-            'Unable to expand module items for "'
-            + cname
-            + '." Please ensure all modules have items'
+            f'Unable to expand module items for "{cname}." Please ensure all modules have items'
         )
     else:
         return items_df

--- a/update_module_progress.py
+++ b/update_module_progress.py
@@ -60,9 +60,8 @@ def main():
             student_items_status = get_student_items_status(
                 course, student_module_status
             )
-        except KeyError as e:
-            print(e)
-            log_failure(cid, e)
+        except KeyError as error:
+            log_failure(cid, error)
         except Unauthorized:
             log_failure(
                 cid,


### PR DESCRIPTION
Would close #23 

Not much has actually changed here. Seems like we already manage these errors managed correctly.

Below 70441 and 71284 have no courses. 71170 has no module items
<img width="1218" alt="Screen Shot 2021-03-16 at 10 52 33 AM" src="https://user-images.githubusercontent.com/22332030/111356929-11d5f780-8646-11eb-8822-e25e70c2809e.png">

One area that _could_ see improvement, but won't ultimately change the behaviour, is to perform checks and catch errors more explicitly. What do I mean? Well in the case of no students in the course, we don't ever actually do a test, but we try and get student module items and catch the "Index Error" and assume what that means (from testing) is that there are no students. A cleaner solution would be to make a call to check if there are students and if not, explicitly throw an error. Why is this better? Because in theory, something else could be causing the "Index Error" but we'd log it as no students being enrolled.

@alisonmyers worth doing? 
