### PR TITLE
Fixing filepaths

### DIFF
--- a/course_entitlements.csv
+++ b/course_entitlements.csv
@@ -1,2 +1,2 @@
-course_id, user_id
-00000, my-user-id
+course_id,user_id
+00000,my-user-id

--- a/course_entitlements.csv
+++ b/course_entitlements.csv
@@ -1,0 +1,2 @@
+course_id, user_id
+00000, my-user-id

--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -351,7 +351,7 @@ def _output_status_table(tableau_path):
 
     dataframe = pd.DataFrame(data, columns=cols)
 
-    file_name = str(current_dt.strftime("%Y-%m-%d %H:%M:%S")) + ".csv"
+    file_name = str(current_dt.strftime("%Y-%m-%d %H.%M.%S")) + ".csv"
 
     status_log_path = Path(f"{settings.ROOT_DIR}/status_log/{file_name}")
     dataframe.to_csv(status_log_path, index=False)

--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -329,7 +329,7 @@ def write_tableau_directory(list_of_dfs):
     shutil.copyfile(src, dst)
 
     current_dt = datetime.datetime.now()
-    dir_name = str(current_dt.strftime("%Y-%m-%d %H:%M:%S"))
+    dir_name = str(current_dt.strftime("%Y-%m-%d %H.%M.%S"))
     src = tableau_path
     dst = Path(f"{root}/archive/{dir_name}")
     shutil.make_archive(dst, "zip", src)

--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -16,6 +16,7 @@ import shutil
 from tqdm import tqdm
 import pandas as pd
 import settings
+from pathlib import Path
 
 
 def create_dict_from_object(theobj, list_of_attributes):
@@ -288,7 +289,8 @@ def write_data_directory(dataframes, cid):
 
     course_path = _make_output_dir(cid)
     for name, dataframe in dataframes.items():
-        dataframe.to_csv("{}/{}.csv".format(course_path, name), index=False)
+        path = Path(f"{course_path}/{name}.csv")
+        dataframe.to_csv(path, index=False)
 
 
 def clear_data_directory():
@@ -298,10 +300,10 @@ def clear_data_directory():
     """
 
     root = os.path.dirname(os.path.abspath(__file__))[:-4]
-    data_path = root + "/data"
+    data_path = Path(f"{root}/data")
 
     for subdir in os.listdir(data_path):
-        path = data_path + "/" + subdir
+        path = data_path / subdir
         if subdir != "Tableau" and subdir != ".gitkeep" and subdir != ".DS_Store":
             shutil.rmtree(path, ignore_errors=False, onerror=None)
 
@@ -316,19 +318,20 @@ def write_tableau_directory(list_of_dfs):
     """
     tableau_path = _make_output_dir("Tableau")
     union = pd.concat(list_of_dfs, axis=0, ignore_index=True)
-    union.to_csv(f"{tableau_path}/module_data.csv", index=False)
+    module_data_output_path = tableau_path / "module_data.csv"
+    union.to_csv(module_data_output_path, index=False)
 
     root = os.path.dirname(os.path.abspath(__file__))[:-4]
 
     # Copy the course_entitlements.csv into the Tableau folder
-    src = root + "/course_entitlements.csv"
-    dst = root + "/data/Tableau/course_entitlements.csv"
+    src = Path(f"{root}/course_entitlements.csv")
+    dst = Path(f"{root}/data/Tableau/course_entitlements.csv")
     shutil.copyfile(src, dst)
 
     current_dt = datetime.datetime.now()
     dir_name = str(current_dt.strftime("%Y-%m-%d %H:%M:%S"))
     src = tableau_path
-    dst = root + "/archive/" + dir_name
+    dst = Path(f"{root}/archive/{dir_name}")
     shutil.make_archive(dst, "zip", src)
     _output_status_table(tableau_path)
 
@@ -349,8 +352,12 @@ def _output_status_table(tableau_path):
     dataframe = pd.DataFrame(data, columns=cols)
 
     file_name = str(current_dt.strftime("%Y-%m-%d %H:%M:%S")) + ".csv"
-    dataframe.to_csv(f"{settings.ROOT_DIR}/status_log/{file_name}", index=False)
-    dataframe.to_csv(tableau_path + "/status.csv", index=False)
+
+    status_log_path = Path(f"{settings.ROOT_DIR}/status_log/{file_name}")
+    dataframe.to_csv(status_log_path, index=False)
+
+    status_path = tableau_path / "status.csv"
+    dataframe.to_csv(status_path, index=False)
 
 
 def log_failure(cid, msg):
@@ -422,7 +429,7 @@ def _make_output_dir(name):
         String: path to the newly created directory
     """
     root = os.path.dirname(os.path.abspath(__file__))[:-4]
-    directory_path = root + "/data/{}".format(name)
+    directory_path = Path(f"{root}/data/{name}")
     # print(directory_path)
     if not os.path.exists(directory_path):
         os.makedirs(directory_path)

--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -122,9 +122,7 @@ def get_items(modules_df, cname):
         )
     except KeyError:
         raise KeyError(
-            'Unable to expand module items for "'
-            + cname
-            + '." Please ensure all modules have items'
+            f'Unable to expand module items for "{cname}." Please ensure all modules have items'
         )
     else:
         return items_df

--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -329,7 +329,7 @@ def write_tableau_directory(list_of_dfs):
     shutil.copyfile(src, dst)
 
     current_dt = datetime.datetime.now()
-    dir_name = str(current_dt.strftime("%Y-%m-%d %H.%M.%S"))
+    dir_name = str(current_dt.strftime("%Y-%m-%d %H-%M-%S"))
     src = tableau_path
     dst = Path(f"{root}/archive/{dir_name}")
     shutil.make_archive(dst, "zip", src)
@@ -351,7 +351,7 @@ def _output_status_table(tableau_path):
 
     dataframe = pd.DataFrame(data, columns=cols)
 
-    file_name = str(current_dt.strftime("%Y-%m-%d %H.%M.%S")) + ".csv"
+    file_name = str(current_dt.strftime("%Y-%m-%d %H-%M-%S")) + ".csv"
 
     status_log_path = Path(f"{settings.ROOT_DIR}/status_log/{file_name}")
     dataframe.to_csv(status_log_path, index=False)

--- a/src/interface.py
+++ b/src/interface.py
@@ -13,6 +13,7 @@ from canvasapi import Canvas
 from canvasapi.exceptions import InvalidAccessToken, ResourceDoesNotExist, Unauthorized
 from pick import pick
 from prettytable import PrettyTable
+from pathlib import Path
 
 import settings
 from .canvas_helpers import log_failure
@@ -166,7 +167,8 @@ def __load_ids():
     cids = []
 
     try:
-        dataframe = pd.read_csv(f"{settings.ROOT_DIR}/course_entitlements.csv")
+        entitlements_path = Path(f"{settings.ROOT_DIR}/course_entitlements.csv")
+        dataframe = pd.read_csv(entitlements_path)
         for index, row in dataframe.iterrows():
             course_id = row["course_id"]
 

--- a/update_module_progress.py
+++ b/update_module_progress.py
@@ -60,9 +60,8 @@ def main():
             student_items_status = get_student_items_status(
                 course, student_module_status
             )
-        except KeyError as e:
-            print(e)
-            log_failure(cid, e)
+        except KeyError as error:
+            log_failure(cid, error)
         except Unauthorized:
             log_failure(
                 cid,


### PR DESCRIPTION
Using pathlib module for python, replaced all hardcoded filepaths with paths built using Path(). This makes all filepaths OS independent and resolves issues we were having on windows machines.