### PR TITLE
Add updates to retrieve course start_at data

### DIFF
--- a/src/canvas_helpers.py
+++ b/src/canvas_helpers.py
@@ -234,6 +234,7 @@ def get_student_items_status(course, module_status):
     ).reset_index(drop=True)
     student_items_status["course_id"] = course.id
     student_items_status["course_name"] = course.name
+    student_items_status["course_start_date"] = course.start_at
 
     # pull out completed_at column as list
     items_status_list = student_items_status["completed_at"].values.tolist()
@@ -270,6 +271,7 @@ def get_student_items_status(course, module_status):
             "item_cp_req_type",
             "item_cp_req_completed",
             "course_name",
+            "course_start_date",
         ]
     ]
 


### PR DESCRIPTION
This code update will allow to retrieve the course start_at data from the Canvas API.  This column of data is required in the open-source Python Dashboard, to compute the average duration of days to complete a module. Please note that this assumes there is always as "start_at" value available for any course. If the field is empty then the plot will still fail. 